### PR TITLE
ci: exclude notebooks from linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: uv run pytest -m "not benchmark"
 
       - name: Run linting
-        run: uv run ruff check .
+        run: uv run ruff check --exclude notebooks .
 
   benchmark:
     name: benchmark-tests


### PR DESCRIPTION
Prevents linting errors in CI for files located within notebook directories.
Notebooks are typically not subject to the same strict linting rules as production code.

Closes #13
