### PR TITLE
fix: calculate Pochhammer symbol in a safer way for kernel derivatives

### DIFF
--- a/src/fftloggin/kernels.py
+++ b/src/fftloggin/kernels.py
@@ -223,8 +223,7 @@ class Derivative(Kernel):
         sign = 1 - 2 * (self.order % 2)
         return (
             sign
-            * special.gamma(s)
-            * special.rgamma(s - self.order)
+            * np.prod(s.reshape(*s.shape, 1) - np.arange(1, self.order + 1), axis=-1)
             * self.transform.forward(s - self.order)
         )
 


### PR DESCRIPTION
Replace `scipy.special.gamma` and `scipy.special.rgamma` with a direct product calculation for kernel derivatives.

This prevents potential numerical overflows and underflows by avoiding the explicit computation of large or small intermediate gamma values. The direct product `(s-1) * (s-2) * ... * (s-order)` is mathematically equivalent and provides improved numerical stability for these calculations.

Closes #17
